### PR TITLE
Cleaning all DRC rules from unnecessary polygons and extended command, Making sure all DRC values are in um

### DIFF
--- a/klayout/drc/rule_decks/comp.drc
+++ b/klayout/drc/rule_decks/comp.drc
@@ -44,13 +44,13 @@ if FEOL
 
   # Rule DF.1a_LV: Min. COMP Width. is 0.22µm
   logger.info('Executing rule DF.1a_LV')
-  df1a_l1 = comp_3p3v.width(0.22.um, euclidian).polygons(0.001)
+  df1a_l1 = comp_3p3v.width(0.22.um, euclidian)
   df1a_l1.output('DF.1a_LV', 'DF.1a_LV : Min. COMP Width. : 0.22µm')
   df1a_l1.forget
 
   # Rule DF.1a_MV: Min. COMP Width. is 0.3µm
   logger.info('Executing rule DF.1a_MV')
-  df1a_l1 = comp_56v.not(mvsd.or(mvpsd)).width(0.3.um, euclidian).polygons(0.001)
+  df1a_l1 = comp_56v.not(mvsd.or(mvpsd)).width(0.3.um, euclidian)
   df1a_l1.output('DF.1a_MV', 'DF.1a_MV : Min. COMP Width. : 0.3µm')
   df1a_l1.forget
 
@@ -62,14 +62,14 @@ if FEOL
 
   # Rule DF.1c: Min. COMP Width for MOSCAP. is 1µm
   logger.info('Executing rule DF.1c')
-  df1c_l1 = comp.and(mos_cap_mk).width(1.um, euclidian).polygons(0.001)
+  df1c_l1 = comp.and(mos_cap_mk).width(1.um, euclidian)
   df1c_l1.output('DF.1c', 'DF.1c : Min. COMP Width for MOSCAP. : 1µm')
   df1c_l1.forget
 
   # Rule DF.2a_LV: Min Channel Width. is 0.22µm
   logger.info('Executing rule DF.2a_LV')
   df_2a_3p3v = comp_3p3v.not(poly2).edges.and(tgate.edges)
-  df2a_l1 = df_2a_3p3v.with_length(nil, 0.22.um).extended(0, 0, 0.001, 0.001)
+  df2a_l1 = df_2a_3p3v.with_length(nil, 0.22.um)
   df2a_l1.output('DF.2a_LV', 'DF.2a_LV : Min Channel Width. : 0.22µm')
   df2a_l1.forget
   df_2a_3p3v.forget
@@ -77,7 +77,7 @@ if FEOL
   # Rule DF.2a_MV: Min Channel Width. is nil,0.3µm
   logger.info('Executing rule DF.2a_MV')
   df_2a_56v = comp_56v.not(poly2).edges.and(tgate.edges)
-  df2a_l1 = df_2a_56v.with_length(nil, 0.3.um).extended(0, 0, 0.001, 0.001)
+  df2a_l1 = df_2a_56v.with_length(nil, 0.3.um)
   df2a_l1.output('DF.2a_MV', 'DF.2a_MV : Min Channel Width. : nil,0.3µm')
   df2a_l1.forget
   df_2a_56v.forget
@@ -94,7 +94,7 @@ if FEOL
   # Rule DF.3a_LV:  Min. COMP Space : 0.28µm. [P-substrate tap (PCOMP outside NWELL and DNWELL)
   ## can be butted for different voltage devices as the potential is same]
   logger.info('Executing rule DF.3a_LV')
-  df3a_l1 = comp_3p3v.not(otp_mk).space(0.28.um, euclidian).polygons(0.001)
+  df3a_l1 = comp_3p3v.not(otp_mk).space(0.28.um, euclidian)
   df3a_l1.output('DF.3a_LV',
                  'DF.3a_LV : Min. COMP Space is : 0.28µm. [P-substrate tap (PCOMP outside NWELL and DNWELL)
                   can be butted for different voltage devices as the potential is same]')
@@ -103,7 +103,7 @@ if FEOL
   # Rule DF.3a_MV:  Min. COMP Space is : 0.36µm. [P-substrate tap (PCOMP outside NWELL and DNWELL)
   ## can be butted for different voltage devices as the potential is same]
   logger.info('Executing rule DF.3a_MV')
-  df3a_l1 = comp_56v.not(otp_mk).space(0.36.um, euclidian).polygons(0.001)
+  df3a_l1 = comp_56v.not(otp_mk).space(0.36.um, euclidian)
   df3a_l1.output('DF.3a_MV',
                  'DF.3a_MV :  Min. COMP Space is : 0.36µm. [P-substrate tap (PCOMP outside NWELL and DNWELL)
                   can be butted for different voltage devices as the potential is same]')
@@ -122,7 +122,7 @@ if FEOL
 
   # Rule DF.3c_LV: Min. COMP Space in BJT area (area marked by DRC_BJT layer). is 0.32µm
   logger.info('Executing rule DF.3c_LV')
-  df3c_l1 = comp_3p3v.and(drc_bjt).space(0.32.um, euclidian).polygons(0.001)
+  df3c_l1 = comp_3p3v.and(drc_bjt).space(0.32.um, euclidian)
   df3c_l1.output('DF.3c_LV', 'DF.3c_LV : Min. COMP Space in BJT area (area marked by DRC_BJT layer). : 0.32µm')
   df3c_l1.forget
 
@@ -135,26 +135,26 @@ if FEOL
 
   # Rule DF.4a_LV: Min. (LVPWELL Space to NCOMP well tap) inside DNWELL. is 0.12µm
   logger.info('Executing rule DF.4a_LV')
-  df4a_l1 = ntap_dn3p3V.separation(lvpwell_dn3p3v, 0.12.um, euclidian).polygons(0.001)
+  df4a_l1 = ntap_dn3p3V.separation(lvpwell_dn3p3v, 0.12.um, euclidian)
   df4a_l1.output('DF.4a_LV', 'DF.4a_LV : Min. (LVPWELL Space to NCOMP well tap) inside DNWELL. : 0.12µm')
   df4a_l1.forget
 
   # Rule DF.4a_MV: Min. (LVPWELL Space to NCOMP well tap) inside DNWELL. is 0.16µm
   logger.info('Executing rule DF.4a_MV')
-  df4a_l1 = ntap_dn56v.separation(lvpwell_dn56v, 0.16.um, euclidian).polygons(0.001)
+  df4a_l1 = ntap_dn56v.separation(lvpwell_dn56v, 0.16.um, euclidian)
   df4a_l1.output('DF.4a_MV', 'DF.4a_MV : Min. (LVPWELL Space to NCOMP well tap) inside DNWELL. : 0.16µm')
   df4a_l1.forget
 
   # Rule DF.4b_LV: Min. DNWELL overlap of NCOMP well tap. is 0.62µm
   logger.info('Executing rule DF.4b_LV')
-  df4b_l1 = ntap_dn3p3V.enclosed(dnwell_3p3v, 0.62.um, euclidian).polygons(0.001)
+  df4b_l1 = ntap_dn3p3V.enclosed(dnwell_3p3v, 0.62.um, euclidian)
   df4b_l1.output('DF.4b_LV', 'DF.4b_LV : Min. DNWELL overlap of NCOMP well tap. : 0.62µm')
   df4b_l1.forget
   ntap_dn3p3V.forget
 
   # Rule DF.4b_MV: Min. DNWELL overlap of NCOMP well tap. is 0.66µm
   logger.info('Executing rule DF.4b_MV')
-  df4b_l1 = ntap_dn56v.enclosed(dnwell_56v, 0.66.um, euclidian).polygons(0.001)
+  df4b_l1 = ntap_dn56v.enclosed(dnwell_56v, 0.66.um, euclidian)
   df4b_l1.output('DF.4b_MV', 'DF.4b_MV : Min. DNWELL overlap of NCOMP well tap. : 0.66µm')
   df4b_l1.forget
   ntap_dn56v.forget
@@ -164,7 +164,7 @@ if FEOL
   nw_n_dn_n_srm = nwell_n_dn.not(sramcore)
   nw_n_dn_n_srm3p3v = nw_n_dn_n_srm.not_interacting(v5_xtor).not_interacting(dualgate)
   df4c_pcomp3p3v = pcomp.and(nw_n_dn_n_srm3p3v)
-  df4c_l1 = df4c_pcomp3p3v.enclosed(nw_n_dn_n_srm3p3v, 0.43.um, euclidian).polygons(0.001)
+  df4c_l1 = df4c_pcomp3p3v.enclosed(nw_n_dn_n_srm3p3v, 0.43.um, euclidian)
   df4c_l1.output('DF.4c_LV', 'DF.4c_LV : Min. (Nwell overlap of PCOMP) outside DNWELL. : 0.43µm')
   df4c_l1.forget
   nw_n_dn_n_srm3p3v.forget
@@ -174,7 +174,7 @@ if FEOL
   logger.info('Executing rule DF.4c_MV')
   nw_n_dn_n_srm56v = nw_n_dn_n_srm.overlapping(dualgate)
   df4c_pcomp56v = pcomp.and(nw_n_dn_n_srm56v)
-  df4c_l1 = df4c_pcomp56v.enclosed(nw_n_dn_n_srm, 0.6.um, euclidian).polygons(0.001)
+  df4c_l1 = df4c_pcomp56v.enclosed(nw_n_dn_n_srm, 0.6.um, euclidian)
   df4c_l1.output('DF.4c_MV', 'DF.4c_MV : Min. (Nwell overlap of PCOMP) outside DNWELL. : 0.6µm')
   df4c_l1.forget
   nw_n_dn_n_srm56v.forget
@@ -185,7 +185,7 @@ if FEOL
   logger.info('Executing rule DF.4d_LV')
   df_4d_nwell = nwell_n_dn.not(ymtp_mk).not(neo_ee_mk)
   df_4d_ncomp3p3v = ncomp_3p3v.and(df_4d_nwell)
-  df4d_l1 = df_4d_ncomp3p3v.enclosed(df_4d_nwell, 0.12.um, euclidian).polygons(0.001)
+  df4d_l1 = df_4d_ncomp3p3v.enclosed(df_4d_nwell, 0.12.um, euclidian)
   df4d_l1.output('DF.4d_LV', 'DF.4d_LV : Min. (Nwell overlap of NCOMP) outside DNWELL. : 0.12µm')
   df4d_l1.forget
   df_4d_ncomp3p3v.forget
@@ -193,32 +193,32 @@ if FEOL
   # Rule DF.4d_MV: Min. (Nwell overlap of NCOMP) outside DNWELL. is 0.16µm
   logger.info('Executing rule DF.4d_MV')
   df_4d_ncomp56v = ncomp_56v.and(df_4d_nwell)
-  df4d_l1 = df_4d_ncomp56v.enclosed(df_4d_nwell, 0.16.um, euclidian).polygons(0.001)
+  df4d_l1 = df_4d_ncomp56v.enclosed(df_4d_nwell, 0.16.um, euclidian)
   df4d_l1.output('DF.4d_MV', 'DF.4d_MV : Min. (Nwell overlap of NCOMP) outside DNWELL. : 0.16µm')
   df4d_l1.forget
   df_4d_ncomp56v.forget
 
   # Rule DF.4e_LV: Min. DNWELL overlap of PCOMP. is 0.93µm
   logger.info('Executing rule DF.4e_LV')
-  df4e_l1 = pcomp_dn3p3v.enclosed(dnwell_3p3v, 0.93.um, euclidian).polygons(0.001)
+  df4e_l1 = pcomp_dn3p3v.enclosed(dnwell_3p3v, 0.93.um, euclidian)
   df4e_l1.output('DF.4e_LV', 'DF.4e_LV : Min. DNWELL overlap of PCOMP. : 0.93µm')
   df4e_l1.forget
 
   # Rule DF.4e_MV: Min. DNWELL overlap of PCOMP. is 1.1µm
   logger.info('Executing rule DF.4e_MV')
-  df4e_l1 = pcomp_dn56v.enclosed(dnwell_56v, 1.1.um, euclidian).polygons(0.001)
+  df4e_l1 = pcomp_dn56v.enclosed(dnwell_56v, 1.1.um, euclidian)
   df4e_l1.output('DF.4e_MV', 'DF.4e_MV : Min. DNWELL overlap of PCOMP. : 1.1µm')
   df4e_l1.forget
 
   # Rule DF.5_LV: Min. (LVPWELL overlap of PCOMP well tap) inside DNWELL. is 0.12µm
   logger.info('Executing rule DF.5_LV')
-  df5_l1 = ptap.and(lvpwell_dn3p3v).enclosed(lvpwell_dn3p3v, 0.12.um, euclidian).polygons(0.001)
+  df5_l1 = ptap.and(lvpwell_dn3p3v).enclosed(lvpwell_dn3p3v, 0.12.um, euclidian)
   df5_l1.output('DF.5_LV', 'DF.5_LV : Min. (LVPWELL overlap of PCOMP well tap) inside DNWELL. : 0.12µm')
   df5_l1.forget
 
   # Rule DF.5_MV: Min. (LVPWELL overlap of PCOMP well tap) inside DNWELL. is 0.16µm
   logger.info('Executing rule DF.5_MV')
-  df5_l1 = ptap.and(lvpwell_dn56v).enclosed(lvpwell_dn56v, 0.16.um, euclidian).polygons(0.001)
+  df5_l1 = ptap.and(lvpwell_dn56v).enclosed(lvpwell_dn56v, 0.16.um, euclidian)
   df5_l1.output('DF.5_MV', 'DF.5_MV : Min. (LVPWELL overlap of PCOMP well tap) inside DNWELL. : 0.16µm')
   df5_l1.forget
 
@@ -227,13 +227,13 @@ if FEOL
   df6_exclude = otp_mk.or(ymtp_mk).or(sramcore).or(mvsd).or(mvpsd)
   df6_comp = comp.interacting(tgate).not(df6_exclude)
   df6_poly = poly2.not(df6_exclude)
-  df6_l1 = df6_poly.enclosed(comp_3p3v.and(df6_comp), 0.24.um, euclidian).polygons(0.001)
+  df6_l1 = df6_poly.enclosed(comp_3p3v.and(df6_comp), 0.24.um, euclidian)
   df6_l1.output('DF.6_LV', 'DF.6_LV : Min. COMP extend beyond gate (it also means source/drain overhang). : 0.24µm')
   df6_l1.forget
 
   # Rule DF.6_MV: Min. COMP extend beyond gate (it also means source/drain overhang). is 0.4µm
   logger.info('Executing rule DF.6_MV')
-  df6_l1 = df6_poly.enclosed(comp_56v.and(df6_comp), 0.4.um, euclidian).polygons(0.001)
+  df6_l1 = df6_poly.enclosed(comp_56v.and(df6_comp), 0.4.um, euclidian)
   df6_l1.output('DF.6_MV', 'DF.6_MV : Min. COMP extend beyond gate (it also means source/drain overhang). : 0.4µm')
   df6_l1.forget
   df6_exclude.forget
@@ -242,14 +242,14 @@ if FEOL
 
   # Rule DF.7_LV: Min. (LVPWELL Spacer to PCOMP) inside DNWELL. is 0.43µm
   logger.info('Executing rule DF.7_LV')
-  df7_l1 = pcomp_dn3p3v.separation(lvpwell_dn3p3v, 0.43.um, euclidian).polygons(0.001)
+  df7_l1 = pcomp_dn3p3v.separation(lvpwell_dn3p3v, 0.43.um, euclidian)
   df7_l1.output('DF.7_LV', 'DF.7_LV : Min. (LVPWELL Spacer to PCOMP) inside DNWELL. : 0.43µm')
   df7_l1.forget
   pcomp_dn3p3v.forget
 
   # Rule DF.7_MV: Min. (LVPWELL Spacer to PCOMP) inside DNWELL. is 0.6µm
   logger.info('Executing rule DF.7_MV')
-  df7_l1 = pcomp_dn56v.not(sramcore).separation(lvpwell_dn56v, 0.6.um, euclidian).polygons(0.001)
+  df7_l1 = pcomp_dn56v.not(sramcore).separation(lvpwell_dn56v, 0.6.um, euclidian)
   df7_l1.output('DF.7_MV', 'DF.7_MV : Min. (LVPWELL Spacer to PCOMP) inside DNWELL. : 0.6µm')
   df7_l1.forget
   pcomp_dn56v.forget
@@ -257,7 +257,7 @@ if FEOL
   # Rule DF.8_LV: Min. (LVPWELL overlap of NCOMP) Inside DNWELL. is 0.43µm
   logger.info('Executing rule DF.8_LV')
   ncomp_dn3p3v = ncomp.and(dnwell_3p3v)
-  df8_l1 = ncomp_dn3p3v.and(lvpwell_dn3p3v).enclosed(lvpwell_dn3p3v, 0.43.um, euclidian).polygons(0.001)
+  df8_l1 = ncomp_dn3p3v.and(lvpwell_dn3p3v).enclosed(lvpwell_dn3p3v, 0.43.um, euclidian)
   df8_l1.output('DF.8_LV', 'DF.8_LV : Min. (LVPWELL overlap of NCOMP) Inside DNWELL. : 0.43µm')
   df8_l1.forget
   ncomp_dn3p3v.forget
@@ -265,7 +265,7 @@ if FEOL
   # Rule DF.8_MV: Min. (LVPWELL overlap of NCOMP) Inside DNWELL. is 0.6µm
   logger.info('Executing rule DF.8_MV')
   ncomp_dn56v = ncomp.and(dnwell_56v)
-  df8_l1 = ncomp_dn56v.and(lvpwell_dn56v).not(sramcore).enclosed(lvpwell_dn56v, 0.6.um, euclidian).polygons(0.001)
+  df8_l1 = ncomp_dn56v.and(lvpwell_dn56v).not(sramcore).enclosed(lvpwell_dn56v, 0.6.um, euclidian)
   df8_l1.output('DF.8_MV', 'DF.8_MV : Min. (LVPWELL overlap of NCOMP) Inside DNWELL. : 0.6µm')
   df8_l1.forget
   ncomp_dn56v.forget
@@ -375,7 +375,7 @@ if FEOL
   logger.info('Executing rule DF.16_LV')
   df16_l1 = ncomp_out_nw_dn.interacting(ncomp_3p3v).not(ymtp_mk.or(sramcore)).separation(
     nwell_n_dn3p3v.not(ymtp_mk), 0.43.um, euclidian
-  ).polygons(0.001)
+  )
   df16_l1.output('DF.16_LV',
                  'DF.16_LV : Min. space from (Nwell outside DNWELL) to (NCOMP outside Nwell and DNWELL). : 0.43µm')
   df16_l1.forget
@@ -384,7 +384,7 @@ if FEOL
   logger.info('Executing rule DF.16_MV')
   df16_l1 = ncomp_out_nw_dn.interacting(ncomp_56v).not_inside(ymtp_mk.or(sramcore)).separation(
     nwell_n_dn56v.not(ymtp_mk), 0.6.um, euclidian
-  ).polygons(0.001)
+  )
   df16_l1.output('DF.16_MV',
                  'DF.16_MV : Min. space from (Nwell outside DNWELL) to (NCOMP outside Nwell and DNWELL). : 0.6µm')
   df16_l1.forget
@@ -392,7 +392,7 @@ if FEOL
   # Rule DF.17_LV: Min. space from (Nwell Outside DNWELL) to (PCOMP outside Nwell and DNWELL) is 0.12µm.
   logger.info('Executing rule DF.17_LV')
   pcomp_3p3v = pplus.and(comp_3p3v)
-  df17_l1 = pcomp_3p3v.and(pcomp_out_nw_dn).separation(nwell_n_dn3p3v, 0.12.um, euclidian).polygons(0.001)
+  df17_l1 = pcomp_3p3v.and(pcomp_out_nw_dn).separation(nwell_n_dn3p3v, 0.12.um, euclidian)
   df17_l1.output('DF.17_LV',
                  'DF.17_LV : Min. space from (Nwell Outside DNWELL) to (PCOMP outside Nwell and DNWELL). : 0.12µm')
   df17_l1.forget
@@ -402,7 +402,7 @@ if FEOL
   # Rule DF.17_MV: Min. space from (Nwell Outside DNWELL) to (PCOMP outside Nwell and DNWELL) is 0.16µm.
   logger.info('Executing rule DF.17_MV')
   pcomp_56v = pplus.and(comp_56v)
-  df17_l1 = pcomp_56v.and(pcomp_out_nw_dn).separation(nwell_n_dn56v, 0.16.um, euclidian).polygons(0.001)
+  df17_l1 = pcomp_56v.and(pcomp_out_nw_dn).separation(nwell_n_dn56v, 0.16.um, euclidian)
   df17_l1.output('DF.17_MV',
                  'DF.17_MV : Min. space from (Nwell Outside DNWELL) to (PCOMP outside Nwell and DNWELL). : 0.16µm')
   df17_l1.forget
@@ -411,21 +411,21 @@ if FEOL
 
   # Rule DF.18: Min. DNWELL space to (PCOMP outside Nwell and DNWELL) is 2.5µm.
   logger.info('Executing rule DF.18')
-  df18_l1 = pcomp_out_nw_dn.separation(dnwell, 2.5.um, euclidian).polygons(0.001)
+  df18_l1 = pcomp_out_nw_dn.separation(dnwell, 2.5.um, euclidian)
   df18_l1.output('DF.18', 'DF.18 : Min. DNWELL space to (PCOMP outside Nwell and DNWELL). : 2.5µm')
   df18_l1.forget
   pcomp_out_nw_dn.forget
 
   # Rule DF.19_LV: Min. DNWELL space to (NCOMP outside Nwell and DNWELL) is 3.2µm.
   logger.info('Executing rule DF.19_LV')
-  df19_l1 = ncomp_out_nw_dn.interacting(ncomp_3p3v).separation(dnwell, 3.2.um, euclidian).polygons(0.001)
+  df19_l1 = ncomp_out_nw_dn.interacting(ncomp_3p3v).separation(dnwell, 3.2.um, euclidian)
   df19_l1.output('DF.19_LV', 'DF.19_LV : Min. DNWELL space to (NCOMP outside Nwell and DNWELL). : 3.2µm')
   df19_l1.forget
   ncomp_3p3v.forget
 
   # Rule DF.19_MV: Min. DNWELL space to (NCOMP outside Nwell and DNWELL) is 3.28µm.
   logger.info('Executing rule DF.19_MV')
-  df19_l1 = ncomp_out_nw_dn.interacting(ncomp_56v).separation(dnwell, 3.28.um, euclidian).polygons(0.001)
+  df19_l1 = ncomp_out_nw_dn.interacting(ncomp_56v).separation(dnwell, 3.28.um, euclidian)
   df19_l1.output('DF.19_MV', 'DF.19_MV : Min. DNWELL space to (NCOMP outside Nwell and DNWELL). : 3.28µm')
   df19_l1.forget
   ncomp_out_nw_dn.forget

--- a/klayout/drc/rule_decks/contact.drc
+++ b/klayout/drc/rule_decks/contact.drc
@@ -55,7 +55,7 @@ if FEOL
 
   # Rule CO.3: Poly2 overlap of contact. is 0.07µm
   logger.info('Executing rule CO.3')
-  co3_l1 = main_contact.enclosed(poly2, 0.07.um, euclidian).polygons(0.001)
+  co3_l1 = main_contact.enclosed(poly2, 0.07.um, euclidian).polygons(0.001.um)
   co3_l2 = main_contact.not_outside(poly2).not(poly2)
   co3_l = co3_l1.or(co3_l2)
   co3_l.output('CO.3', 'CO.3 : Poly2 overlap of contact. : 0.07µm')
@@ -65,7 +65,7 @@ if FEOL
 
   # Rule CO.4: COMP overlap of contact. is 0.07µm
   logger.info('Executing rule CO.4')
-  co4_l1 = main_contact.enclosed(comp, 0.07.um, euclidian).polygons(0.001)
+  co4_l1 = main_contact.enclosed(comp, 0.07.um, euclidian).polygons(0.001.um)
   co4_l2 = main_contact.not_outside(comp).not(comp)
   co4_l = co4_l1.or(co4_l2)
   co4_l.output('CO.4', 'CO.4 : COMP overlap of contact. : 0.07µm')
@@ -99,7 +99,7 @@ if FEOL
 
   # Rule CO.6: Metal1 overlap of contact >= 0.005 um.
   logger.info('Executing rule CO.6')
-  co6_l1 = contact.enclosed(metal1, 0.005.um, euclidian).polygons(0.001)
+  co6_l1 = contact.enclosed(metal1, 0.005.um, euclidian).polygons(0.001.um)
   co6_l2 = contact.not(metal1)
   co6_l = co6_l1.or(co6_l2)
   co6_l.output('CO.6', 'CO.6 : Metal1 overlap of contact >= 0.005 um')
@@ -134,8 +134,8 @@ if FEOL
   cont_6b_cond_edges = main_contact_edges.not_outside(main_contact.enclosed(metal1, 0.04.um, projection).edges)
   cont_6b_check_corner = cont_6b_cond_edges.extended_in(0.002.um)
   cont_6b_check = main_contact_edges.interacting(cont_6b_check_corner).not(cont_6b_cond_edges)
-  cont_6b_cond_corner = cont_6b_cond_edges.width(0.002.um, angle_limit(135)).polygons(0.001)
-  cont_6b_l1 = cont_6b_check.enclosed(metal1_edges, 0.06.um, projection).polygons(0.001)
+  cont_6b_cond_corner = cont_6b_cond_edges.width(0.002.um, angle_limit(135)).polygons(0.001.um)
+  cont_6b_l1 = cont_6b_check.enclosed(metal1_edges, 0.06.um, projection).polygons(0.001.um)
   cont_6b_l2 = main_contact.interacting(cont_6b_cond_corner)
   cont_6b_l = cont_6b_l1.or(cont_6b_l2)
   cont_6b_l.output('CO.6b', 'CO.6b : (ii) If Metal1 overlaps contact by < 0.04um on one side,

--- a/klayout/drc/rule_decks/dualgate.drc
+++ b/klayout/drc/rule_decks/dualgate.drc
@@ -21,7 +21,7 @@ if FEOL
 
   # Rule DV.1: Min. Dualgate enclose DNWELL. is 0.5µm
   logger.info('Executing rule DV.1')
-  dv1_l1 = dualgate.enclosing(dnwell, 0.5.um, euclidian).polygons(0.001)
+  dv1_l1 = dualgate.enclosing(dnwell, 0.5.um, euclidian).polygons(0.001.um)
   dv1_l2 = dnwell.not_outside(dualgate).not(dualgate)
   dv1_l  = dv1_l1.or(dv1_l2)
   dv1_l.output('DV.1', 'DV.1 : Min. Dualgate enclose DNWELL. : 0.5µm')
@@ -31,13 +31,13 @@ if FEOL
 
   # Rule DV.2: Min. Dualgate Space. Merge if Space is less than this design rule. is 0.44µm
   logger.info('Executing rule DV.2')
-  dv2_l1 = dualgate.space(0.44.um, euclidian).polygons(0.001)
+  dv2_l1 = dualgate.space(0.44.um, euclidian)
   dv2_l1.output('DV.2', 'DV.2 : Min. Dualgate Space. Merge if Space is less than this design rule. : 0.44µm')
   dv2_l1.forget
 
   # Rule DV.3: Min. Dualgate to COMP space [unrelated]. is 0.24µm
   logger.info('Executing rule DV.3')
-  dv3_l1 = dualgate.separation(comp.outside(dualgate), 0.24.um, euclidian).polygons(0.001)
+  dv3_l1 = dualgate.separation(comp.outside(dualgate), 0.24.um, euclidian)
   dv3_l1.output('DV.3', 'DV.3 : Min. Dualgate to COMP space [unrelated]. : 0.24µm')
   dv3_l1.forget
 
@@ -46,14 +46,14 @@ if FEOL
 
   # Rule DV.5: Min. Dualgate width. is 0.7µm
   logger.info('Executing rule DV.5')
-  dv5_l1 = dualgate.width(0.7.um, euclidian).polygons(0.001)
+  dv5_l1 = dualgate.width(0.7.um, euclidian)
   dv5_l1.output('DV.5', 'DV.5 : Min. Dualgate width. : 0.7µm')
   dv5_l1.forget
 
   comp_dv = comp.not(pcomp.outside(nwell))
   # Rule DV.6: Min. Dualgate enclose COMP (except substrate tap). is 0.24µm
   logger.info('Executing rule DV.6')
-  dv6_l1 = dualgate.enclosing(comp_dv, 0.24.um, euclidian).polygons(0.001)
+  dv6_l1 = dualgate.enclosing(comp_dv, 0.24.um, euclidian).polygons(0.001.um)
   dv6_l2 = comp_dv.not_outside(dualgate).not(dualgate)
   dv6_l  = dv6_l1.or(dv6_l2)
   dv6_l.output('DV.6', 'DV.6 : Min. Dualgate enclose COMP (except substrate tap). : 0.24µm')
@@ -71,7 +71,7 @@ if FEOL
 
   # Rule DV.8: Min Dualgate enclose Poly2. is 0.4µm
   logger.info('Executing rule DV.8')
-  dv8_l1 = dualgate.enclosing(poly2, 0.4.um, euclidian).polygons(0.001)
+  dv8_l1 = dualgate.enclosing(poly2, 0.4.um, euclidian).polygons(0.001.um)
   dv8_l2 = poly2.not_outside(dualgate).not(dualgate)
   dv8_l  = dv8_l1.or(dv8_l2)
   dv8_l.output('DV.8', 'DV.8 : Min Dualgate enclose Poly2. : 0.4µm')

--- a/klayout/drc/rule_decks/efuse.drc
+++ b/klayout/drc/rule_decks/efuse.drc
@@ -134,13 +134,13 @@ ef11_l1.forget
 # Rule EF.12: Min. Space of Cathode Contact to PLFUSE end.
 logger.info('Executing rule EF.12')
 cont_ef = contact.and(plfuse_efuse)
-ef12_l1 = plfuse_efuse.separation(contact.and(cathode), 0.155.um).polygons(0.001).join(cont_ef)
+ef12_l1 = plfuse_efuse.separation(contact.and(cathode), 0.155.um).polygons(0.001.um).join(cont_ef)
 ef12_l1.output('EF.12', 'EF.12 : Min. Space of Cathode Contact to PLFUSE end.')
 ef12_l1.forget
 
 # Rule EF.13: Min. Space of Anode Contact to PLFUSE end.
 logger.info('Executing rule EF.13')
-ef13_l1 = plfuse_efuse.separation(contact.and(anode), 0.14.um).polygons(0.001).join(cont_ef)
+ef13_l1 = plfuse_efuse.separation(contact.and(anode), 0.14.um).polygons(0.001.um).join(cont_ef)
 ef13_l1.output('EF.13', 'EF.13 : Min. Space of Anode Contact to PLFUSE end.')
 ef13_l1.forget
 cont_ef.forget

--- a/klayout/drc/rule_decks/hres.drc
+++ b/klayout/drc/rule_decks/hres.drc
@@ -43,7 +43,7 @@ if FEOL
 
   # Rule HRES.4: Minimum RESISTOR overlap of Poly2 resistor. is 0.4µm
   logger.info('Executing rule HRES.4')
-  hres4_l1 = hres_poly.enclosed(resistor, 0.4.um, euclidian).polygons(0.001)
+  hres4_l1 = hres_poly.enclosed(resistor, 0.4.um, euclidian).polygons(0.001.um)
   hres4_l2 = hres_poly.not_outside(resistor).not(resistor)
   hres4_l  = hres4_l1.or(hres4_l2)
   hres4_l.output('HRES.4', 'HRES.4 : Minimum RESISTOR overlap of Poly2 resistor. : 0.4µm')
@@ -59,7 +59,7 @@ if FEOL
 
   # Rule HRES.6: Minimum RESISTOR space to COMP.
   logger.info('Executing rule HRES.6')
-  hres6_l1 = resistor.interacting(hres1_poly).separation(comp, 0.3.um, euclidian).polygons(0.001)
+  hres6_l1 = resistor.interacting(hres1_poly).separation(comp, 0.3.um, euclidian).polygons(0.001.um)
   hres6_l2 = comp.not_outside(resistor.interacting(hres1_poly))
   hres6_l = hres6_l1.or(hres6_l2)
   hres6_l.output('HRES.6', 'HRES.6 : Minimum RESISTOR space to COMP.')
@@ -70,7 +70,7 @@ if FEOL
 
   # Rule HRES.7: Minimum Pplus overlap of contact on Poly2 resistor. is 0.2µm
   logger.info('Executing rule HRES.7')
-  hres7_l1 = contact.and(hres_poly).enclosed(pplus, 0.2.um, euclidian).polygons(0.001)
+  hres7_l1 = contact.and(hres_poly).enclosed(pplus, 0.2.um, euclidian).polygons(0.001.um)
   hres7_l2 = contact.and(hres_poly).not_outside(pplus).not(pplus)
   hres7_l  = hres7_l1.or(hres7_l2)
   hres7_l.output('HRES.7', 'HRES.7 : Minimum Pplus overlap of contact on Poly2 resistor. : 0.2µm')
@@ -81,7 +81,7 @@ if FEOL
   # Rule HRES.8: Space from salicide block to contact on Poly2 resistor.
   logger.info('Executing rule HRES.8')
   hres8_l1 = contact.and(hres_poly).separation(sab,
-                                               0.22.um).polygons(0.001).or(contact.and(hres_poly).interacting(sab))
+                                               0.22.um).polygons(0.001.um).or(contact.and(hres_poly).interacting(sab))
   hres8_l1.output('HRES.8', 'HRES.8 : Space from salicide block to contact on Poly2 resistor.')
   hres8_l1.forget
 
@@ -89,11 +89,11 @@ if FEOL
   logger.info('Executing rule HRES.9')
   hres9_sab             = sab.interacting(pplus).interacting(res_mk).interacting(resistor)
   hres9_clear_sab       = hres9_sab.not(hres_poly)
-  hres9_bad_inside_edge = hres9_sab.edges.inside_part(hres_poly).extended(0, 0, 0.001, 0.001).interacting(
+  hres9_bad_inside_edge = hres9_sab.edges.inside_part(hres_poly).extended(0, 0, 0.001.um, 0.001.um).interacting(
     hres9_clear_sab, 1, 1
   )
   hres9_sab_hole = hres9_sab.holes.and(hres_poly)
-  hres9_l1 = hres_poly.enclosed(hres9_sab, 0.28.um, euclidian).polygons(0.001)
+  hres9_l1 = hres_poly.enclosed(hres9_sab, 0.28.um, euclidian).polygons(0.001.um)
   hres9_l2 = hres9_bad_inside_edge.or(hres9_sab_hole)
   hres9_l = hres9_l1.or(hres9_l2)
   hres9_l.output('HRES.9', 'HRES.9 : Minimum salicide block overlap of Poly2 resistor in width direction.')
@@ -109,7 +109,7 @@ if FEOL
   logger.info('Executing rule HRES.10')
   pplus1_hres10 = pplus.and(sab).drc(width != 0.1.um)
   pplus2_hres10 = pplus.not_overlapping(sab).edges
-  hres10_l1 = pplus1_hres10.or(pplus2_hres10).extended(0, 0, 0.001, 0.001).interacting(hres_poly)
+  hres10_l1 = pplus1_hres10.or(pplus2_hres10).extended(0, 0, 0.001.um, 0.001.um).interacting(hres_poly)
   hres10_l1.output('HRES.10', 'HRES.10 : Minimum & maximum Pplus overlap of SAB.')
   hres10_l1.forget
   pplus1_hres10.forget

--- a/klayout/drc/rule_decks/ldnmos.drc
+++ b/klayout/drc/rule_decks/ldnmos.drc
@@ -101,7 +101,7 @@ if FEOL
   logger.info('Executing rule MDN.5ai')
   pcomp_mdn5ai = pcomp_mdn.not_interacting(ncomp)
   mdn5ai_l1 = mvsd.and(pcomp_mdn5ai)
-  mdn5ai_l2 = pcomp_mdn5ai.separation(mvsd, 1.um, euclidian).polygons(0.001)
+  mdn5ai_l2 = pcomp_mdn5ai.separation(mvsd, 1.um, euclidian).polygons(0.001.um)
   mdn5ai_l = mdn5ai_l1.join(mdn5ai_l2)
   mdn5ai_l.output('MDN.5ai', "MDN.5ai : Min PCOMP (Pplus AND COMP) space to LDNMOS Drain MVSD
                     (source and body tap non-butted): 1um. PCOMP (Pplus AND COMP)
@@ -117,7 +117,7 @@ if FEOL
   logger.info('Executing rule MDN.5aii')
   pcomp_mdn5aii = pcomp_mdn.interacting(ncomp)
   mdn5aii_l1  = mvsd.and(pcomp_mdn5aii)
-  mdn5aii_l2  = pcomp_mdn5aii.separation(mvsd, 0.92.um, euclidian).polygons(0.001)
+  mdn5aii_l2  = pcomp_mdn5aii.separation(mvsd, 0.92.um, euclidian).polygons(0.001.um)
   mdn5aii_l = mdn5aii_l1.join(mdn5aii_l2)
   mdn5aii_l.output('MDN.5aii', "MDN.5aii : Min PCOMP (Pplus AND COMP) space to LDNMOS Drain MVSD
                      (source and body tap butted): 0.92um. PCOMP (Pplus AND COMP)
@@ -144,7 +144,7 @@ if FEOL
   # Rule MDN.5c: Maximum distance of the nearest edge of the substrate tab from NCOMP edge is 15µm.
   logger.info('Executing rule MDN.5c')
   mdn_5c_ncompsd = ncomp_mdn.interacting(mvsd).sized(0.36.um).sized(-0.36.um).extents
-  mdn_5c_error_exclude = mdn_5c_ncompsd.drc(separation(pcomp, euclidian) <= 15.um).polygons(0.001)
+  mdn_5c_error_exclude = mdn_5c_ncompsd.drc(separation(pcomp, euclidian) <= 15.um).polygons(0.001.um)
   mdn_5c_error = mdn_5c_ncompsd.edges.centers(0, 0.99).not_interacting(mdn_5c_error_exclude)
   mdn5c_l1 = mdn_5c_error.and(ncomp).and(pcomp_holes)
   mdn5c_l1.output('MDN.5c',
@@ -162,7 +162,7 @@ if FEOL
 
   # Rule MDN.6a: Min Dualgate enclose NCOMP.
   logger.info('Executing rule MDN.6a')
-  mdn6a_l1 = ncomp_ld.enclosed(dualgate, 0.5.um, euclidian).polygons(0.001).join(ncomp_ld.not(dualgate))
+  mdn6a_l1 = ncomp_ld.enclosed(dualgate, 0.5.um, euclidian).polygons(0.001.um).join(ncomp_ld.not(dualgate))
   mdn6a_l1.output('MDN.6a', 'MDN.6a : Min Dualgate enclose NCOMP.')
   mdn6a_l1.forget
 
@@ -201,7 +201,7 @@ if FEOL
     logger.info('CONNECTIVITY_RULES disabled section')
     # Rule MDN.8b: Min LDNMOS drain MVSD space to any other different potential Nwell space.
     logger.info('Executing rule MDN.8b')
-    mdn8b_l1 = mvsd.separation(nwell, 2.um, euclidian).polygons(0.001).join(mvsd.not_outside(nwell))
+    mdn8b_l1 = mvsd.separation(nwell, 2.um, euclidian).polygons(0.001.um).join(mvsd.not_outside(nwell))
 
   end
   mdn8b_l1.output('MDN.8b', 'MDN.8b : Min LDNMOS drain MVSD space to any other different potential Nwell space.')
@@ -252,7 +252,7 @@ if FEOL
   mdn_10d_not_max = ncomp_mdn.inside(mvsd).drc(separation(mdn_10d_field) <= 0.16.um)
   mdn_10d_ext     = ncomp.sized(0.36.um).sized(-0.36.um).extents
   mdn_10d_max     = mdn_10d_ext.not(mdn_10d_not_max.polygons).not(ncomp).not(poly2).inside(mvsd)
-  mdn_10d_min     = ncomp_mdn.inside(mvsd).separation(mdn_10d_field, 0.16.um).polygons(0.001)
+  mdn_10d_min     = ncomp_mdn.inside(mvsd).separation(mdn_10d_field, 0.16.um).polygons(0.001.um)
   mdn_10d_overlap = ncomp_mdn.inside(mvsd).and(poly2)
   mdn10d_l1 = mdn_10d_max.join(mdn_10d_min).join(mdn_10d_overlap)
   mdn10d_l1.output('MDN.10d', 'MDN.10d : Min/Max POLY2 on field space to LDNMOS drain COMP.')
@@ -266,7 +266,7 @@ if FEOL
 
   # Rule MDN.10ei: Min POLY2 space to Psub tap (source and body tap non-butted).
   logger.info('Executing rule MDN.10ei')
-  mdn10ei_l1 = poly_mdn10.separation(pcomp.not_interacting(ncomp), 0.4.um).polygons(0.001)
+  mdn10ei_l1 = poly_mdn10.separation(pcomp.not_interacting(ncomp), 0.4.um).polygons(0.001.um)
   mdn10ei_l2 = poly_mdn10.and(pcomp.not_interacting(ncomp))
   mdn10ei_l = mdn10ei_l1.join(mdn10ei_l2)
   mdn10ei_l.output('MDN.10ei', 'MDN.10ei : Min POLY2 space to Psub tap (source and body tap non-butted).')
@@ -297,7 +297,7 @@ if FEOL
   logger.info('Executing rule MDN.11')
   mdn_11_layer      = ldmos_xtor.and(mvsd).and(comp).and(poly2).and(nplus)
   mdn_11_max        = mdn_11_layer.not(mdn_11_layer.drc(width <= 0.4.um).polygons)
-  mdn_11_min        = mdn_11_layer.width(0.4.um).polygons(0.001).not_interacting(mdn_11_max)
+  mdn_11_min        = mdn_11_layer.width(0.4.um).polygons(0.001.um).not_interacting(mdn_11_max)
   mdn_11_no_channel_l1 = mvsd.covering(ncomp).outside(tgate).and(dualgate).and(ldmos_xtor)
   mdn_11_no_channel_l2 = mvsd.not_covering(ncomp.not_interacting(poly2)).and(dualgate).and(ldmos_xtor)
   mdn_11_no_channel = mdn_11_no_channel_l1.join(mdn_11_no_channel_l2)
@@ -316,7 +316,7 @@ if FEOL
   ## and in the direction along the transistor width.
   logger.info('Executing rule MDN.12')
   mdn12_a1 = mvsd_mdn.covering(ncomp_mdn.not_interacting(poly2))
-  mdn12_a = ncomp_mdn.enclosed(mdn12_a1, 0.5.um, transparent).polygons(0.001).outside(poly2)
+  mdn12_a = ncomp_mdn.enclosed(mdn12_a1, 0.5.um, transparent).polygons(0.001.um).outside(poly2)
   mdn12_b = mvsd_mdn.not_covering(ncomp.not_interacting(poly2))
   mdn12_l1 = mdn12_a.join(mdn12_b)
   mdn12_l1.output('MDN.12', 'MDN.12 : Min MVSD enclose NCOMP in the LDNMOS drain
@@ -383,7 +383,7 @@ if FEOL
 
   # Rule MDN.14: Min MVSD space to any DNWELL.
   logger.info('Executing rule MDN.14')
-  mdn14_l1 = mvsd.separation(dnwell, 6.0.um).polygons(0.001).join(mvsd.not_outside(dnwell))
+  mdn14_l1 = mvsd.separation(dnwell, 6.0.um).polygons(0.001.um).join(mvsd.not_outside(dnwell))
   mdn14_l1.output('MDN.14', 'MDN.14 : Min MVSD space to any DNWELL.')
   mdn14_l1.forget
 

--- a/klayout/drc/rule_decks/ldpmos.drc
+++ b/klayout/drc/rule_decks/ldpmos.drc
@@ -62,7 +62,7 @@ if FEOL
   ## intercept with MVPSD is not allowed.
   logger.info('Executing rule MDP.3ai')
   ncomp_mdp3ai = ncomp.not_interacting(pcomp).and(ldmos_xtor).and(dualgate)
-  mdp3ai_l1 = ncomp_mdp3ai.separation(mvpsd, 1.um, euclidian).polygons(0.001).join(mvpsd.interacting(ncomp_mdp3ai))
+  mdp3ai_l1 = ncomp_mdp3ai.separation(mvpsd, 1.um, euclidian).polygons(0.001.um).join(mvpsd.interacting(ncomp_mdp3ai))
   mdp3ai_l1.output('MDP.3ai', 'MDP.3ai : Min NCOMP (Nplus AND COMP) space to MVPSD
                    (source and body tap non-butted). NCOMP (Nplus AND COMP)
                    intercept with MVPSD is not allowed.')
@@ -73,7 +73,7 @@ if FEOL
   ## NCOMP (Nplus AND COMP) intercept with MVPSD is not allowed.
   logger.info('Executing rule MDP.3aii')
   ncomp_mdp3aii = ncomp.interacting(pcomp).and(ldmos_xtor).and(dualgate)
-  mdp3aii_l1 = ncomp_mdp3aii.separation(mvpsd, 0.92.um, euclidian).polygons(0.001)
+  mdp3aii_l1 = ncomp_mdp3aii.separation(mvpsd, 0.92.um, euclidian).polygons(0.001.um)
   mdp3aii_l2 = mvpsd.interacting(ncomp_mdp3aii)
   mdp3aii_l = mdp3aii_l1.join(mdp3aii_l2)
   mdp3aii_l.output('MDP.3aii', 'MDP.3aii : Min NCOMP (Nplus AND COMP) space to MVPSD (source and body tap butted).
@@ -149,8 +149,8 @@ if FEOL
   logger.info('Executing rule MDP.4b')
   mdp4b_dnwell_edges = dnwell.inside(ldmos_xtor).inside(dualgate).edges.centers(0, 0.99)
   mdp4b_pcomp = pcomp.inside(ldmos_xtor.interacting(mvpsd)).inside(dualgate).not_interacting(mvpsd)
-  mdp4b_not_error = dnwell.drc(separation(mdp4b_pcomp, euclidian) <= 15.um).polygons(0.001)
-  mdp4b_l1 = mdp4b_dnwell_edges.not_interacting(mdp4b_not_error).and(pcomp.holes).extended(0, 0, 0.001, 0.001)
+  mdp4b_not_error = dnwell.drc(separation(mdp4b_pcomp, euclidian) <= 15.um).polygons(0.001.um)
+  mdp4b_l1 = mdp4b_dnwell_edges.not_interacting(mdp4b_not_error).and(pcomp.holes)
   mdp4b_l1.output('MDP.4b', 'MDP.4b : Maximum distance of the nearest edge of the DNWELL
                 from the PCOMP Guard ring outside DNWELL. : 15µm')
   mdp4b_l1.forget
@@ -166,7 +166,7 @@ if FEOL
   # Rule MDP.5a: Minimum Dualgate enclose Plus guarding ring PCOMP (Pplus AND COMP). is 0.5µm
   logger.info('Executing rule MDP.5a')
   pcomp_mdp5a = pcomp.inside(ldmos_xtor)
-  mdp5a_l1 = pcomp_mdp5a.enclosed(dualgate.and(ldmos_xtor), 0.5.um, euclidian).polygons(0.001)
+  mdp5a_l1 = pcomp_mdp5a.enclosed(dualgate.and(ldmos_xtor), 0.5.um, euclidian).polygons(0.001.um)
   mdp5a_l2 = pcomp_mdp5a.not_outside(dualgate.and(ldmos_xtor)).not(dualgate.and(ldmos_xtor))
   mdp5a_l  = mdp5a_l1.join(mdp5a_l2)
   mdp5a_l.output('MDP.5a', 'MDP.5a : Minimum Dualgate enclose Plus guarding ring PCOMP (Pplus AND COMP). : 0.5µm')
@@ -189,19 +189,19 @@ if FEOL
 
   # Rule MDP.7: Minimum LDMOS_XTOR layer space to Nwell outside LDMOS_XTOR. is 2µm
   logger.info('Executing rule MDP.7')
-  mdp7_l1 = ldmos_xtor.separation(nwell.outside(ldmos_xtor), 2.um, euclidian).polygons(0.001)
+  mdp7_l1 = ldmos_xtor.separation(nwell.outside(ldmos_xtor), 2.um, euclidian)
   mdp7_l1.output('MDP.7', 'MDP.7 : Minimum LDMOS_XTOR layer space to Nwell outside LDMOS_XTOR. : 2µm')
   mdp7_l1.forget
 
   # Rule MDP.8: Minimum LDMOS_XTOR layer space to NCOMP outside LDMOS_XTOR. is 1.5µm
   logger.info('Executing rule MDP.8')
-  mdp8_l1 = ldmos_xtor.separation(ncomp.outside(ldmos_xtor), 1.5.um, euclidian).polygons(0.001)
+  mdp8_l1 = ldmos_xtor.separation(ncomp.outside(ldmos_xtor), 1.5.um, euclidian)
   mdp8_l1.output('MDP.8', 'MDP.8 : Minimum LDMOS_XTOR layer space to NCOMP outside LDMOS_XTOR. : 1.5µm')
   mdp8_l1.forget
 
   # Rule MDP.9a: Min LDPMOS POLY2 width. is 1.2µm
   logger.info('Executing rule MDP.9a')
-  mdp9a_l1 = poly2.inside(dnwell_mdp).width(1.2.um, euclidian).polygons(0.001)
+  mdp9a_l1 = poly2.inside(dnwell_mdp).width(1.2.um, euclidian)
   mdp9a_l1.output('MDP.9a', 'MDP.9a : Min LDPMOS POLY2 width. : 1.2µm')
   mdp9a_l1.forget
 
@@ -245,7 +245,8 @@ if FEOL
   ## (source and body tap non-butted).
   ldpmos_poly2_gate = poly2.interacting(pgate.and(dualgate).not(mvpsd))
   ncomp_not_butted = ncomp.not(pplus).not_interacting(pcomp.not(nplus)).or(ncomp.overlapping(pcomp))
-  mdp9ei_a = ldpmos_poly2_gate.inside(dualgate).inside(ldmos_xtor).separation(ncomp_not_butted, 0.4.um).polygons(0.001)
+  mdp9ei_a = ldpmos_poly2_gate.inside(dualgate).inside(ldmos_xtor).separation(ncomp_not_butted,
+                                                                              0.4.um).polygons(0.001.um)
   mdp9ei_b = ldpmos_poly2_gate.inside(dualgate).inside(ldmos_xtor).and(ncomp_not_butted)
   logger.info('Executing rule MDP.9ei')
   mdp9ei_l1 = mdp9ei_a.or(mdp9ei_b)
@@ -261,7 +262,7 @@ if FEOL
   logger.info('Executing rule MDP.9eii')
   ncomp_butted = ncomp.interacting(pcomp)
   ldpmos_poly2_gate_mdp = ldpmos_poly2_gate.and(dualgate).and(ldmos_xtor)
-  mdp9eii_a    = ldpmos_poly2_gate_mdp.separation(ncomp_butted, 0.32.um).polygons(0.001)
+  mdp9eii_a    = ldpmos_poly2_gate_mdp.separation(ncomp_butted, 0.32.um).polygons(0.001.um)
   mdp9eii_b    = ldpmos_poly2_gate_mdp.and(ncomp_butted)
   mdp9eii_l1 = mdp9eii_a.join(mdp9eii_b)
   mdp9eii_l1.output('MDP.9eii', "MDP.9eii : Min LDMPOS gate Poly2 space to Nplus guardring
@@ -315,7 +316,7 @@ if FEOL
 
     # Rule MDP.10a: Min MVPSD space within LDMOS_XTOR marking [diff potential]. is 2µm
     logger.info('Executing rule MDP.10a')
-    mdp10a_l1 = mvpsd.space(2.um, euclidian).polygons(0.001)
+    mdp10a_l1 = mvpsd.space(2.um, euclidian)
     mdp10a_l1.output('MDP.10a', 'MDP.10a : Min MVPSD space within LDMOS_XTOR marking [diff potential]. : 2µm')
     mdp10a_l1.forget
 
@@ -324,7 +325,7 @@ if FEOL
   # Rule MDP.11: Min MVPSD enclosing PCOMP in the drain
   ## (MVPSD AND COMP NOT POLY2) direction and in the direction along the transistor width.
   logger.info('Executing rule MDP.11')
-  mdp11_l1 = mvpsd.edges.not_interacting(pcomp.edges).enclosing(pcomp.edges, 0.8.um, euclidian).polygons(0.001)
+  mdp11_l1 = mvpsd.edges.not_interacting(pcomp.edges).enclosing(pcomp.edges, 0.8.um, euclidian).polygons(0.001.um)
   mdp11_l2 = mvpsd.interacting(mvpsd.edges.and(pcomp.edges))
   mdp11_l = mdp11_l1.join(mdp11_l2)
   mdp11_l.output('MDP.11', "MDP.11 : Min MVPSD enclosing PCOMP in the drain
@@ -335,7 +336,7 @@ if FEOL
 
   # Rule MDP.12: Min DNWELL enclose Nplus guard ring (NCOMP). is 0.66µm
   logger.info('Executing rule MDP.12')
-  mdp12_l1 = dnwell_mdp.enclosing(ncomp.inside(dualgate).inside(ldmos_xtor), 0.66.um, euclidian).polygons(0.001)
+  mdp12_l1 = dnwell_mdp.enclosing(ncomp.inside(dualgate).inside(ldmos_xtor), 0.66.um, euclidian).polygons(0.001.um)
   mdp12_l2 = ncomp.inside(dualgate).inside(ldmos_xtor).not_outside(dnwell_mdp).not(dnwell_mdp)
   mdp12_l  = mdp12_l1.join(mdp12_l2)
   mdp12_l.output('MDP.12', 'MDP.12 : Min DNWELL enclose Nplus guard ring (NCOMP). : 0.66µm')
@@ -403,7 +404,7 @@ if FEOL
   mdp17_a1 = mvpsd.inside(dnwell).inside(ldmos_xtor)
   mdp17_a2 = ncomp.outside(dnwell).outside(nwell)
   mdp17a_l1 = mdp17_a1.separation(mdp17_a2, transparent,
-                                  40.um).polygons(0.001).not_interacting(ncomp.and(dnwell).holes)
+                                  40.um).polygons(0.001.um).not_interacting(ncomp.and(dnwell).holes)
   mdp17a_l1.output('MDP.17a', "MDP.17a : For better latch up immunity, it is necessary to put DNWELL
                       guard ring between MVPSD Inside DNWELL covered by LDMOS_XTOR and NCOMP
                       (outside DNWELL and outside Nwell) when spacing between them is less than 40um.")

--- a/klayout/drc/rule_decks/lres.drc
+++ b/klayout/drc/rule_decks/lres.drc
@@ -36,7 +36,7 @@ if FEOL
 
   # Rule LRES.3: Minimum space from Poly2 resistor to COMP.
   logger.info('Executing rule LRES.3')
-  lres3_l1 = lres_poly.separation(comp, 0.6.um, euclidian).polygons(0.001).or(comp.not_outside(lres_poly))
+  lres3_l1 = lres_poly.separation(comp, 0.6.um, euclidian).polygons(0.001.um).or(comp.not_outside(lres_poly))
   lres3_l1.output('LRES.3', 'LRES.3 : Minimum space from Poly2 resistor to COMP.')
   lres3_l1.forget
 
@@ -48,7 +48,7 @@ if FEOL
 
   # Rule LRES.5: Minimum Nplus implant overlap of Poly2 resistor. is 0.3µm
   logger.info('Executing rule LRES.5')
-  lres5_l1 = lres_poly.enclosed(nplus, 0.3.um, euclidian).polygons(0.001)
+  lres5_l1 = lres_poly.enclosed(nplus, 0.3.um, euclidian).polygons(0.001.um)
   lres5_l2 = lres_poly.not_outside(nplus).not(nplus)
   lres5_l  = lres5_l1.or(lres5_l2)
   lres5_l.output('LRES.5', 'LRES.5 : Minimum Nplus implant overlap of Poly2 resistor. : 0.3µm')
@@ -65,7 +65,7 @@ if FEOL
   # Rule LRES.7: Space from salicide block to contact on Poly2 resistor.
   logger.info('Executing rule LRES.7')
   cont_lres7 = contact.and(lres_poly)
-  lres7_l1 = cont_lres7.separation(sab, 0.22.um).polygons(0.001)
+  lres7_l1 = cont_lres7.separation(sab, 0.22.um).polygons(0.001.um)
   lres7_l2 = cont_lres7.interacting(sab)
   lres7_l = lres7_l1.or(lres7_l2)
   lres7_l.output('LRES.7', 'LRES.7 : Space from salicide block to contact on Poly2 resistor.')

--- a/klayout/drc/rule_decks/lvpwell.drc
+++ b/klayout/drc/rule_decks/lvpwell.drc
@@ -88,7 +88,7 @@ if FEOL
 
   # Rule LPW.3: Min. DNWELL enclose LVPWELL. is 2.5µm
   logger.info('Executing rule LPW.3_LV')
-  lpw3_l1 = dnwell.enclosing(lvpwell_dn, 2.5.um, euclidian).polygons(0.001)
+  lpw3_l1 = dnwell.enclosing(lvpwell_dn, 2.5.um, euclidian).polygons(0.001.um)
   lpw3_l2 = lvpwell_dn.not(dnwell)
   lpw3_l = lpw3_l1.or(lpw3_l2)
   lpw3_l.output('LPW.3', 'LPW.3 : Min. DNWELL enclose LVPWELL. : 2.5µm')

--- a/klayout/drc/rule_decks/main.drc
+++ b/klayout/drc/rule_decks/main.drc
@@ -911,16 +911,16 @@ end
 def conn_space(layer, conn_val, not_conn_val, mode)
   if layer.respond_to?(:nets) # KLayout version (>=0.28.4) which supports "nets"
     nets = layer.nets
-    connected_output   = nets.space(conn_val.um, mode, props_eq).polygons(0.001)
-    singularity_errors = nets.space(0.001.um, mode).polygons(0.001)
-    unconnected_output = nets.space(not_conn_val.um, mode, props_ne).polygons(0.001).join(singularity_errors)
+    connected_output   = nets.space(conn_val.um, mode, props_eq).polygons(0.001.um)
+    singularity_errors = nets.space(0.001.um, mode).polygons(0.001.um)
+    unconnected_output = nets.space(not_conn_val.um, mode, props_ne).polygons(0.001.um).join(singularity_errors)
     nets.forget
   else
     raise 'ERROR : Wrong connectivity implementation' if conn_val > not_conn_val
 
-    connected_output = layer.space(conn_val.um, mode).polygons(0.001)
+    connected_output = layer.space(conn_val.um, mode).polygons(0.001.um)
     unconnected_errors = conn_space_check(layer, not_conn_val, mode)
-    singularity_errors = layer.space(0.001.um, mode).polygons(0.001)
+    singularity_errors = layer.space(0.001.um, mode).polygons(0.001.um)
     unconnected_output = unconnected_errors.polygons.join(singularity_errors)
   end
   [connected_output, unconnected_output]
@@ -947,16 +947,16 @@ def conn_separation(layer1, layer2, conn_val, not_conn_val, mode)
   if layer1.respond_to?(:nets) # KLayout version (>=0.28.4) which supports "nets"
     nets1 = layer1.nets
     nets2 = layer2.nets
-    connected_output   = nets1.separation(nets2, conn_val.um,     mode, props_eq).polygons(0.001)
-    unconnected_output = nets1.separation(nets2, not_conn_val.um, mode, props_ne).polygons(0.001)
+    connected_output   = nets1.separation(nets2, conn_val.um,     mode, props_eq).polygons(0.001.um)
+    unconnected_output = nets1.separation(nets2, not_conn_val.um, mode, props_ne).polygons(0.001.um)
     nets1.forget
     nets2.forget
   else
     raise 'ERROR : Wrong connectivity implementation' if conn_val > not_conn_val
 
-    connected_output = layer1.separation(layer2, conn_val.um, mode).polygons(0.001)
+    connected_output = layer1.separation(layer2, conn_val.um, mode).polygons(0.001.um)
     unconnected_errors = conn_separation_check(layer, not_conn_val, mode)
-    unconnected_output = unconnected_errors.polygons(0.001)
+    unconnected_output = unconnected_errors.polygons(0.001.um)
   end
   [connected_output, unconnected_output]
 end

--- a/klayout/drc/rule_decks/metaltop_30k.drc
+++ b/klayout/drc/rule_decks/metaltop_30k.drc
@@ -59,7 +59,7 @@ if BEOL && (METAL_TOP == '30K')
   # Rule MT30.5: Minimum thick MetalTop enclose underlying via
   ## (for example: via5 for 6LM case) [Outside Not Allowed] is 0.12um.
   logger.info('Executing rule MT30.5')
-  mt305_l1 = top_via.enclosed(top_metal, 0.12.um, euclidian).polygons(0.001)
+  mt305_l1 = top_via.enclosed(top_metal, 0.12.um, euclidian).polygons(0.001.um)
   mt305_l2 = top_via.not_inside(top_metal)
   mt305_l = mt305_l1.join(mt305_l2)
   mt305_l.output('MT30.5', "MT30.5 : Minimum thick MetalTop enclose underlying via

--- a/klayout/drc/rule_decks/mim_a.drc
+++ b/klayout/drc/rule_decks/mim_a.drc
@@ -36,7 +36,7 @@ if MIM_OPTION == 'A'
   ## (referenced to virtual bottom plate)]. is 0.4µm
   logger.info('Executing rule MIM.2')
   mim2_via = via2.overlapping(mim_virtual)
-  mim2_l1 = mim2_via.enclosed(metal2, 0.4.um, euclidian).polygons(0.001)
+  mim2_l1 = mim2_via.enclosed(metal2, 0.4.um, euclidian).polygons(0.001.um)
   mim2_l2 = mim2_via.not_outside(metal2).not(metal2)
   mim2_l  = mim2_l1.join(mim2_l2)
   mim2_l.output('MIM.2', 'MIM.2 : Minimum MiM bottom plate overlap of Via2 layer.
@@ -49,7 +49,7 @@ if MIM_OPTION == 'A'
 
   # Rule MIM.3: Minimum MiM bottom plate overlap of Top plate.
   logger.info('Executing rule MIM.3')
-  mim3_l1 = fusetop.enclosed(mim_virtual, 0.6.um).polygons(0.001)
+  mim3_l1 = fusetop.enclosed(mim_virtual, 0.6.um).polygons(0.001.um)
   mim3_l2 = fusetop.not_inside(mim_virtual)
   mim3_l = mim3_l1.join(mim3_l2)
   mim3_l.output('MIM.3', 'MIM.3 : Minimum MiM bottom plate overlap of Top plate.')
@@ -59,7 +59,7 @@ if MIM_OPTION == 'A'
 
   # Rule MIM.4: Minimum MiM top plate (FuseTop) overlap of Via2. is 0.4µm
   logger.info('Executing rule MIM.4')
-  mim4_l1 = via2.enclosed(fusetop, 0.4.um, euclidian).polygons(0.001)
+  mim4_l1 = via2.enclosed(fusetop, 0.4.um, euclidian).polygons(0.001.um)
   mim4_l2 = via2.not_outside(fusetop).not(fusetop)
   mim4_l  = mim4_l1.join(mim4_l2)
   mim4_l.output('MIM.4', 'MIM.4 : Minimum MiM top plate (FuseTop) overlap of Via2. : 0.4µm')

--- a/klayout/drc/rule_decks/mim_b.drc
+++ b/klayout/drc/rule_decks/mim_b.drc
@@ -36,7 +36,7 @@ if MIM_OPTION == 'B'
   ## (referenced to virtual bottom plate)]. is 0.4µm
   logger.info('Executing rule MIMTM.2')
   mimtm_via = top_via.overlapping(mimtm_virtual)
-  mimtm2_l1 = mimtm_via.enclosed(topmin1_metal, 0.4.um, euclidian).polygons(0.001)
+  mimtm2_l1 = mimtm_via.enclosed(topmin1_metal, 0.4.um, euclidian).polygons(0.001.um)
   mimtm2_l2 = mimtm_via.not_outside(topmin1_metal).not(topmin1_metal)
   mimtm2_l  = mimtm2_l1.join(mimtm2_l2)
   mimtm2_l.output('MIMTM.2', "MIMTM.2 : Minimum MiM bottom plate overlap of Vian-1 layer.
@@ -49,7 +49,7 @@ if MIM_OPTION == 'B'
 
   # Rule MIMTM.3: Minimum MiM bottom plate overlap of Top plate.
   logger.info('Executing rule MIMTM.3')
-  mimtm3_l1 = fusetop.enclosed(mimtm_virtual, 0.6.um).polygons(0.001)
+  mimtm3_l1 = fusetop.enclosed(mimtm_virtual, 0.6.um).polygons(0.001.um)
   mimtm3_l2 = fusetop.not_inside(mimtm_virtual)
   mimtm3_l = mimtm3_l1.join(mimtm3_l2)
   mimtm3_l.output('MIMTM.3', 'MIMTM.3 : Minimum MiM bottom plate overlap of Top plate.')
@@ -60,7 +60,7 @@ if MIM_OPTION == 'B'
 
   # Rule MIMTM.4: Minimum MiM top plate (FuseTop) overlap of Vian-1 is 0.4µm.
   logger.info('Executing rule MIMTM.4')
-  mimtm4_l1 = fusetop.enclosing(top_via, 0.4.um, euclidian).polygons(0.001)
+  mimtm4_l1 = fusetop.enclosing(top_via, 0.4.um, euclidian).polygons(0.001.um)
   mimtm4_l2 = top_via.not_outside(fusetop).not(fusetop)
   mimtm4_l  = mimtm4_l1.join(mimtm4_l2)
   mimtm4_l.output('MIMTM.4', 'MIMTM.4 : Minimum MiM top plate (FuseTop) overlap of Vian-1: 0.4µm')
@@ -103,7 +103,7 @@ if MIM_OPTION == 'B'
 
   # Rule MIMTM.9: Min. Via (Vian-1) spacing for sea of Via on MIM top plate. is 0.5µm
   logger.info('Executing rule MIMTM.9')
-  mimtm9_l1 = top_via.inside(fusetop).space(0.5.um, euclidian).polygons(0.001)
+  mimtm9_l1 = top_via.inside(fusetop).space(0.5.um, euclidian)
   mimtm9_l1.output('MIMTM.9', 'MIMTM.9 : Min. Via (Vian-1) spacing for sea of Via on MIM top plate. : 0.5µm')
   mimtm9_l1.forget
 

--- a/klayout/drc/rule_decks/nat.drc
+++ b/klayout/drc/rule_decks/nat.drc
@@ -91,7 +91,7 @@ if FEOL
   ## minimum spacing of un-related poly from the NAT layer is 0.3um
   logger.info('Executing rule NAT.9')
   nat9_a = poly2.and(nat).not(ncomp).interacting(ngate.and(nat), 2)
-  nat9_b = poly2.not(nat).separation(nat, 0.3.um, euclidian).polygons(0.001)
+  nat9_b = poly2.not(nat).separation(nat, 0.3.um, euclidian).polygons(0.001.um)
   nat9_l1 = nat9_a.join(nat9_b)
   nat9_l1.output('NAT.9', "NAT.9 : Poly interconnect under NAT layer is not allowed,
                     minimum spacing of un-related poly from the NAT layer: 0.3um")

--- a/klayout/drc/rule_decks/nplus.drc
+++ b/klayout/drc/rule_decks/nplus.drc
@@ -116,7 +116,7 @@ if FEOL
   ## to the direction of Poly2.
   np_4b_poly = poly2.edges.interacting(pgate.edges.not(pcomp_edges)).centers(0, 0.99).and(pgate.sized(0.32.um))
   logger.info('Executing rule NP.4b')
-  np4b_l1 = nplus.interacting(nplus_edges.separation(np_4b_poly, 0.22.um, projection).polygons(0.001))
+  np4b_l1 = nplus.interacting(nplus_edges.separation(np_4b_poly, 0.22.um, projection).polygons(0.001.um))
   np4b_l1.output('NP.4b', 'NP.4b : Within 0.32um of channel, space to P-channel gate extension perpendicular
                   to the direction of Poly2.')
   np4b_l1.forget
@@ -124,7 +124,7 @@ if FEOL
 
   # Rule NP.5a: Overlap of N-channel gate. is 0.23µm
   logger.info('Executing rule NP.5a')
-  np5a_l1 = ngate.enclosed(nplus, 0.23.um, euclidian).polygons(0.001)
+  np5a_l1 = ngate.enclosed(nplus, 0.23.um, euclidian).polygons(0.001.um)
   np5a_l2 = ngate.not_outside(nplus).not(nplus)
   np5a_l  = np5a_l1.or(np5a_l2)
   np5a_l.output('NP.5a', 'NP.5a : Overlap of N-channel gate. : 0.23µm')
@@ -149,7 +149,7 @@ if FEOL
   logger.info('Executing rule NP.5ci')
   np_5ci_background = nplus.not_inside(lvpwell).inside(dnwell).edges
   np_5ci_foreground = ncomp.not_inside(lvpwell).inside(dnwell).edges.not(pplus.edges).and(lvpwell_dn_sized_out)
-  np5ci_l1 = np_5ci_background.enclosing(np_5ci_foreground, 0.16.um, projection).polygons(0.001)
+  np5ci_l1 = np_5ci_background.enclosing(np_5ci_foreground, 0.16.um, projection)
   np5ci_l1.output('NP.5ci', 'NP.5ci : Extension beyond COMP: For Inside DNWELL: (i)For Nplus < 0.43um
                    from LVPWELL edge for Nwell or DNWELL tap inside DNWELL. : 0.16µm')
   np5ci_l1.forget
@@ -161,7 +161,7 @@ if FEOL
   logger.info('Executing rule NP.5cii')
   np_5cii_background = nplus.not_inside(lvpwell).inside(dnwell).edges
   np_5cii_foreground = ncomp.not_inside(lvpwell).inside(dnwell).edges.not(pplus.edges).not(lvpwell_dn_sized_out)
-  np5cii_l1 = np_5cii_background.enclosing(np_5cii_foreground, 0.02.um, projection).polygons(0.001)
+  np5cii_l1 = np_5cii_background.enclosing(np_5cii_foreground, 0.02.um, projection)
   np5cii_l1.output('NP.5cii', 'NP.5cii : Extension beyond COMP: For Inside DNWELL: (ii) For Nplus >= 0.43um
                     from LVPWELL edge for Nwell or DNWELL tap inside DNWELL. : 0.02µm')
   np5cii_l1.forget
@@ -223,7 +223,7 @@ if FEOL
 
   # Rule NP.9: Overlap of unsalicided Poly2. is 0.18µm
   logger.info('Executing rule NP.9')
-  np9_l1 = nplus.enclosing(poly2.and(sab), 0.18.um, euclidian).polygons(0.001)
+  np9_l1 = nplus.enclosing(poly2.and(sab), 0.18.um, euclidian).polygons(0.001.um)
   np9_l2 = poly2.and(sab).not_outside(nplus).not(nplus)
   np9_l  = np9_l1.or(np9_l2)
   np9_l.output('NP.9', 'NP.9 : Overlap of unsalicided Poly2. : 0.18µm')
@@ -261,7 +261,7 @@ if FEOL
   ## within 0.32um of P-channel gate.
   logger.info('Executing rule NP.12')
   np12_l1 = nplus.interacting(nplus_edges.separation(pgate.edges.and(pcomp_edges), 0.32.um,
-                                                     euclidian).polygons(0.001))
+                                                     euclidian).polygons(0.001.um))
   np12_l1.output('NP.12', 'NP.12 : Overlap with P-channel poly2 gate extension is forbidden
                   within 0.32um of P-channel gate.')
   np12_l1.forget

--- a/klayout/drc/rule_decks/nwell.drc
+++ b/klayout/drc/rule_decks/nwell.drc
@@ -120,7 +120,7 @@ if FEOL
 
   # Rule NW.5_LV: Min. DNWELL enclose Nwell is 0.5µm.
   logger.info('Executing rule NW.5_LV')
-  nw5_l1 = nw_lv.enclosed(dnwell, 0.5.um, euclidian).polygons(0.001)
+  nw5_l1 = nw_lv.enclosed(dnwell, 0.5.um, euclidian).polygons(0.001.um)
   nw5_l2 = nw_lv.not_outside(dnwell).not(dnwell)
   nw5_l  = nw5_l1.join(nw5_l2)
   nw5_l.output('NW.5_LV', 'NW.5_LV : Min. DNWELL enclose Nwell: 0.5µm')
@@ -131,7 +131,7 @@ if FEOL
 
   # Rule NW.5_MV: Min. DNWELL enclose Nwell is 0.5µm.
   logger.info('Executing rule NW.5_MV')
-  nw5_l1 = nw_mv.enclosed(dnwell, 0.5.um, euclidian).polygons(0.001)
+  nw5_l1 = nw_mv.enclosed(dnwell, 0.5.um, euclidian).polygons(0.001.um)
   nw5_l2 = nwell.not_outside(dnwell).not(dnwell)
   nw5_l  = nw5_l1.join(nw5_l2)
   nw5_l.output('NW.5_MV', 'NW.5_MV : Min. DNWELL enclose Nwell: 0.5µm')

--- a/klayout/drc/rule_decks/otp_mk.drc
+++ b/klayout/drc/rule_decks/otp_mk.drc
@@ -84,7 +84,7 @@ if FEOL
 
   # Rule O.SB.4: Min. space from salicide block to contact.
   logger.info('Executing rule O.SB.4')
-  osb4_l1 = sab_otp.separation(contact, 0.03.um, euclidian).polygons(0.001).or(sab_otp.and(contact))
+  osb4_l1 = sab_otp.separation(contact, 0.03.um, euclidian).polygons(0.001.um).or(sab_otp.and(contact))
   osb4_l1.output('O.SB.4', 'O.SB.4 : Min. space from salicide block to contact.')
   osb4_l1.forget
 

--- a/klayout/drc/rule_decks/pplus.drc
+++ b/klayout/drc/rule_decks/pplus.drc
@@ -115,7 +115,7 @@ if FEOL
   ## extension perpendicular to the direction of Poly2.
   logger.info('Executing rule PP.4b')
   pp_4b_poly = poly2.edges.interacting(ngate.edges.not(ncomp_edges)).centers(0, 0.99).and(ngate.sized(0.32.um))
-  pp4b_l1 = pplus.interacting(pplus_edges.separation(pp_4b_poly, 0.22.um, projection).polygons(0.001))
+  pp4b_l1 = pplus.interacting(pplus_edges.separation(pp_4b_poly, 0.22.um, projection).polygons(0.001.um))
   pp4b_l1.output('PP.4b', "PP.4b : Within 0.32um of channel, space to N-channel gate
                     extension perpendicular to the direction of Poly2.")
   pp4b_l1.forget
@@ -123,7 +123,7 @@ if FEOL
 
   # Rule PP.5a: Overlap of P-channel gate. is 0.23µm
   logger.info('Executing rule PP.5a')
-  pp5a_l1 = pplus.enclosing(pgate, 0.23.um, euclidian).polygons(0.001)
+  pp5a_l1 = pplus.enclosing(pgate, 0.23.um, euclidian).polygons(0.001.um)
   pp5a_l2 = pgate.not_outside(pplus).not(pplus)
   pp5a_l  = pp5a_l1.or(pp5a_l2)
   pp5a_l.output('PP.5a', 'PP.5a : Overlap of P-channel gate. : 0.23µm')
@@ -222,7 +222,7 @@ if FEOL
 
   # Rule PP.9: Overlap of unsalicided Poly2. is 0.18µm
   logger.info('Executing rule PP.9')
-  pp9_l1 = pplus.enclosing(poly2.not_interacting(resistor).and(sab), 0.18.um, euclidian).polygons(0.001)
+  pp9_l1 = pplus.enclosing(poly2.not_interacting(resistor).and(sab), 0.18.um, euclidian).polygons(0.001.um)
   pp9_l2 = poly2.not_interacting(resistor).and(sab).not_outside(pplus).not(pplus)
   pp9_l  = pp9_l1.or(pp9_l2)
   pp9_l.output('PP.9', 'PP.9 : Overlap of unsalicided Poly2. : 0.18µm')
@@ -259,7 +259,7 @@ if FEOL
   ##  within 0.32um of N-channel gate.
   logger.info('Executing rule PP.12')
   pp12_l1 = pplus.interacting(pplus_edges.separation(ngate.edges.and(ncomp_edges), 0.32.um,
-                                                     euclidian).polygons(0.001))
+                                                     euclidian).polygons(0.001.um))
   pp12_l1.output('PP.12', "PP.12 : Overlap with N-channel Poly2 gate extension is forbidden
                     within 0.32um of N-channel gate.")
   pp12_l1.forget

--- a/klayout/drc/rule_decks/pres.drc
+++ b/klayout/drc/rule_decks/pres.drc
@@ -36,7 +36,7 @@ if FEOL
 
   # Rule PRES.3: Minimum space from Poly2 resistor to COMP.
   logger.info('Executing rule PRES.3')
-  pres3_l1 = pres_poly.separation(comp, 0.6.um, euclidian).polygons(0.001)
+  pres3_l1 = pres_poly.separation(comp, 0.6.um, euclidian).polygons(0.001.um)
   pres3_l2 = comp.not_outside(pres_poly)
   pres3_l  = pres3_l1.or(pres3_l2)
   pres3_l.output('PRES.3', 'PRES.3 : Minimum space from Poly2 resistor to COMP.')
@@ -52,7 +52,7 @@ if FEOL
 
   # Rule PRES.5: Minimum Plus implant overlap of Poly2 resistor. is 0.3µm
   logger.info('Executing rule PRES.5')
-  pres5_l1 = pres_poly.enclosed(pplus, 0.3.um, euclidian).polygons(0.001)
+  pres5_l1 = pres_poly.enclosed(pplus, 0.3.um, euclidian).polygons(0.001.um)
   pres5_l2 = pres_poly.not_outside(pplus).not(pplus)
   pres5_l  = pres5_l1.or(pres5_l2)
   pres5_l.output('PRES.5', 'PRES.5 : Minimum Plus implant overlap of Poly2 resistor. : 0.3µm')
@@ -68,7 +68,7 @@ if FEOL
 
   # Rule PRES.7: Space from salicide block to contact on Poly2 resistor.
   logger.info('Executing rule PRES.7')
-  pres7_l1 = contact.and(pres_poly).separation(sab, 0.22.um).polygons(0.001)
+  pres7_l1 = contact.and(pres_poly).separation(sab, 0.22.um).polygons(0.001.um)
   pres7_l2 = contact.and(pres_poly).interacting(sab)
   pres7_l = pres7_l1.or(pres7_l2)
   pres7_l.output('PRES.7', 'PRES.7 : Space from salicide block to contact on Poly2 resistor.')

--- a/klayout/drc/rule_decks/sab.drc
+++ b/klayout/drc/rule_decks/sab.drc
@@ -49,7 +49,7 @@ if FEOL
 
   # Rule SB.4: Space from salicide block to contact is 0.15 um.
   logger.info('Executing rule SB.4')
-  sb4_l1 = sab_out_otp.separation(contact, 0.15.um, euclidian).polygons(0.001).or(sab_out_otp.and(contact))
+  sb4_l1 = sab_out_otp.separation(contact, 0.15.um, euclidian).polygons(0.001.um).or(sab_out_otp.and(contact))
   sb4_l1.output('SB.4', 'SB.4 : Space from salicide block to contact: 0.15 um')
   sb4_l1.forget
 
@@ -123,7 +123,7 @@ if FEOL
   logger.info('Executing rule SB.14a')
   sb14a_butted_sab_poly = sab_poly.and(pplus).edges.inside(sab_poly.and(nplus).edges)
   sb14a_l1 = sab_poly.and(nplus).separation(sab_poly.and(pplus), 0.56.um,
-                                            square).polygons(0.001).not_interacting(sb14a_butted_sab_poly)
+                                            square).polygons(0.001.um).not_interacting(sb14a_butted_sab_poly)
   sb14a_l1.output('SB.14a', "SB.14a : Space from unsalicided Nplus Poly2 to unsalicided Pplus Poly2.
                     (Unsalicided Nplus Poly2 must not fall within a square of 0.56um x 0.56um
                     at unsalicided Pplus Poly2 corners). : 0.56µm")

--- a/klayout/drc/rule_decks/sram_3p3.drc
+++ b/klayout/drc/rule_decks/sram_3p3.drc
@@ -32,7 +32,7 @@ if FEOL
   # Rule S.DF.4c_LV: Min. (Nwell overlap of PCOMP) outside DNWELL is 0.4µm.
   logger.info('Executing rule S.DF.4c_LV')
   pcomp_out_dn_sram = pcomp.outside(dnwell).and(sram_lv)
-  sdf4c_l1 = pcomp_out_dn_sram.enclosed(nw_n_dn_sram, 0.4.um, euclidian).polygons(0.001)
+  sdf4c_l1 = pcomp_out_dn_sram.enclosed(nw_n_dn_sram, 0.4.um, euclidian).polygons(0.001.um)
   sdf4c_l2 = pcomp_out_dn_sram.not_outside(nw_n_dn_sram).not(nw_n_dn_sram)
   sdf4c_l  = sdf4c_l1.or(sdf4c_l2)
   sdf4c_l.output('S.DF.4c_LV', 'S.DF.4c_LV : Min. (Nwell overlap of PCOMP) outside DNWELL: 0.4µm')
@@ -53,7 +53,7 @@ if FEOL
 
   # Rule S.CO.3_LV: Poly2 overlap of contact is 0.04µm.
   logger.info('Executing rule S.CO.3_LV')
-  sco3_l1 = contact_sram.enclosed(poly_sram, 0.04.um, euclidian).polygons(0.001)
+  sco3_l1 = contact_sram.enclosed(poly_sram, 0.04.um, euclidian).polygons(0.001.um)
   sco3_l2 = contact_sram.not_outside(poly_sram).not(poly_sram)
   sco3_l  = sco3_l1.or(sco3_l2)
   sco3_l.output('S.CO.3_LV', 'S.CO.3_LV : Poly2 overlap of contact: 0.04µm')
@@ -64,7 +64,7 @@ if FEOL
 
   # Rule S.CO.4_LV: COMP overlap of contact is 0.03µm.
   logger.info('Executing rule S.CO.4_LV')
-  sco4_l1 = comp_sram.enclosing(contact_sram, 0.03.um, euclidian).polygons(0.001)
+  sco4_l1 = comp_sram.enclosing(contact_sram, 0.03.um, euclidian).polygons(0.001.um)
   sco4_l2 = contact_sram.not_outside(comp_sram).not(comp_sram)
   sco4_l  = sco4_l1.or(sco4_l2)
   sco4_l.output('S.CO.4_LV', 'S.CO.4_LV : COMP overlap of contact: 0.03µm')

--- a/klayout/drc/rule_decks/sram_5p0.drc
+++ b/klayout/drc/rule_decks/sram_5p0.drc
@@ -32,7 +32,7 @@ if FEOL
   # Rule S.DF.4c_MV: Min. (Nwell overlap of PCOMP) outside DNWELL. is 0.45µm
   logger.info('Executing rule S.DF.4c_MV')
   pcomp_out_dn_sram = pcomp.outside(dnwell).and(sram_mv)
-  sdf4c_l1 = pcomp_out_dn_sram.enclosed(nw_n_dn_sram, 0.45.um, euclidian).polygons(0.001)
+  sdf4c_l1 = pcomp_out_dn_sram.enclosed(nw_n_dn_sram, 0.45.um, euclidian).polygons(0.001.um)
   sdf4c_l2 = pcomp_out_dn_sram.not_outside(nw_n_dn_sram).not(nw_n_dn_sram)
   sdf4c_l  = sdf4c_l1.or(sdf4c_l2)
   sdf4c_l.output('S.DF.4c_MV', 'S.DF.4c_MV : Min. (Nwell overlap of PCOMP) outside DNWELL. : 0.45µm')
@@ -43,7 +43,7 @@ if FEOL
 
   # Rule S.DF.6_MV: Min. COMP extend beyond gate (it also means source/drain overhang). is 0.32µm
   logger.info('Executing rule S.DF.6_MV')
-  sdf6_l1 = poly_sram.enclosed(comp_sram, 0.32.um, euclidian).polygons(0.001)
+  sdf6_l1 = poly_sram.enclosed(comp_sram, 0.32.um, euclidian)
   sdf6_l1.output('S.DF.6_MV',
                  'S.DF.6_MV : Min. COMP extend beyond gate (it also means source/drain overhang). : 0.32µm')
   sdf6_l1.forget
@@ -56,7 +56,7 @@ if FEOL
 
   # Rule S.DF.8_MV: Min. (LVPWELL overlap of NCOMP) Inside DNWELL. is 0.45µm
   logger.info('Executing rule S.DF.8_MV')
-  sdf8_l1 = ncomp_dn_sram.enclosed(lvpwell_dn_sram, 0.45.um, euclidian).polygons(0.001)
+  sdf8_l1 = ncomp_dn_sram.enclosed(lvpwell_dn_sram, 0.45.um, euclidian).polygons(0.001.um)
   sdf8_l2 = ncomp_dn_sram.not_outside(lvpwell_dn_sram).not(lvpwell_dn_sram)
   sdf8_l  = sdf8_l1.or(sdf8_l2)
   sdf8_l.output('S.DF.8_MV', 'S.DF.8_MV : Min. (LVPWELL overlap of NCOMP) Inside DNWELL. : 0.45µm')
@@ -92,7 +92,7 @@ if FEOL
 
   # Rule S.CO.4_MV: COMP overlap of contact. is 0.04µm
   logger.info('Executing rule S.CO.4_MV')
-  sco4_l1 = contact_sram.enclosed(comp_sram, 0.04.um, euclidian).polygons(0.001)
+  sco4_l1 = contact_sram.enclosed(comp_sram, 0.04.um, euclidian).polygons(0.001.um)
   sco4_l2 = contact_sram.not_outside(comp_sram).not(comp_sram)
   sco4_l  = sco4_l1.or(sco4_l2)
   sco4_l.output('S.CO.4_MV', 'S.CO.4_MV : COMP overlap of contact. : 0.04µm')

--- a/klayout/drc/rule_decks/via1.drc
+++ b/klayout/drc/rule_decks/via1.drc
@@ -21,7 +21,7 @@ if BEOL
 
   # Rule V1.1: Min/max Via1 size . is 0.26µm
   logger.info('Executing rule V1.1')
-  v11_l1 = via1.edges.without_length(0.26.um).extended(0, 0, 0.001, 0.001)
+  v11_l1 = via1.edges.without_length(0.26.um)
   v11_l1.output('V1.1', 'V1.1 : Min/max Via1 size . : 0.26µm')
   v11_l1.forget
 
@@ -100,7 +100,7 @@ if BEOL
 
   # Rule V1.4a: metal2 overlap of via1.
   logger.info('Executing rule V1.4a')
-  via1_4a_l1 = via1.enclosed(metal2, 0.01.um, euclidian).polygons(0.001)
+  via1_4a_l1 = via1.enclosed(metal2, 0.01.um, euclidian).polygons(0.001.um)
   via1_4a_l2 = via1.not(metal2)
   via1_4a_l = via1_4a_l1.or(via1_4a_l2)
   via1_4a_l.output('V1.4a', 'V1.4a : metal2 overlap of via1 >= 0.01 um')

--- a/klayout/drc/rule_decks/via2.drc
+++ b/klayout/drc/rule_decks/via2.drc
@@ -22,7 +22,7 @@ if BEOL && (METAL_LEVEL == '3LM' || METAL_LEVEL == '4LM' || METAL_LEVEL == '5LM'
 
   # Rule V2.1: Min/max Via1 size . is 0.26µm
   logger.info('Executing rule V2.1')
-  v21_l1 = via2.edges.without_length(0.26.um).extended(0, 0, 0.001, 0.001)
+  v21_l1 = via2.edges.without_length(0.26.um)
   v21_l1.output('V2.1', 'V2.1 : Min/max Via1 size . : 0.26µm')
   v21_l1.forget
 
@@ -56,7 +56,7 @@ if BEOL && (METAL_LEVEL == '3LM' || METAL_LEVEL == '4LM' || METAL_LEVEL == '5LM'
   # Rule V2.3b: metal2 overlap of via2.
   logger.info('Executing rule V2.3b')
   v23b_l1 = via2.not(metal2)
-  v23b_l2 = via2.enclosed(metal2, 0.01.um, euclidian).polygons(0.001)
+  v23b_l2 = via2.enclosed(metal2, 0.01.um, euclidian).polygons(0.001.um)
   v23b_l = v23b_l1.or(v23b_l2)
   v23b_l.output('V2.3b', 'V2.3b : metal2 overlap of via2 >= 0.01')
   v23b_l1.forget
@@ -106,7 +106,7 @@ if BEOL && (METAL_LEVEL == '3LM' || METAL_LEVEL == '4LM' || METAL_LEVEL == '5LM'
 
   # Rule V2.4a: metal3 overlap of via2.
   logger.info('Executing rule V2.4a')
-  via2_4a_l1 = via2.enclosed(metal3, 0.01.um, euclidian).polygons(0.001)
+  via2_4a_l1 = via2.enclosed(metal3, 0.01.um, euclidian).polygons(0.001.um)
   via2_4a_l2 = via2.not(metal3)
   via2_4a_l = via2_4a_l1.or(via2_4a_l2)
   via2_4a_l.output('V2.4a', 'V2.4a : metal3 overlap of via2 >= 0.01 um')

--- a/klayout/drc/rule_decks/via3.drc
+++ b/klayout/drc/rule_decks/via3.drc
@@ -22,7 +22,7 @@ if BEOL && (METAL_LEVEL == '4LM' || METAL_LEVEL == '5LM' || METAL_LEVEL == '6LM'
 
   # Rule V3.1: Min/max Via1 size . is 0.26µm
   logger.info('Executing rule V3.1')
-  v31_l1 = via3.edges.without_length(0.26.um).extended(0, 0, 0.001, 0.001)
+  v31_l1 = via3.edges.without_length(0.26.um)
   v31_l1.output('V3.1', 'V3.1 : Min/max Via1 size . : 0.26µm')
   v31_l1.forget
 
@@ -56,7 +56,7 @@ if BEOL && (METAL_LEVEL == '4LM' || METAL_LEVEL == '5LM' || METAL_LEVEL == '6LM'
   # Rule V3.3b: metal3 overlap of via3.
   logger.info('Executing rule V3.3b')
   v33b_l1 = via3.not(metal3)
-  v33b_l2 = via3.enclosed(metal3, 0.01.um, euclidian).polygons(0.001)
+  v33b_l2 = via3.enclosed(metal3, 0.01.um, euclidian).polygons(0.001.um)
   v33b_l = v33b_l1.or(v33b_l2)
   v33b_l.output('V3.3b', 'V3.3b : metal3 overlap of via3 >= 0.01')
   v33b_l1.forget
@@ -106,7 +106,7 @@ if BEOL && (METAL_LEVEL == '4LM' || METAL_LEVEL == '5LM' || METAL_LEVEL == '6LM'
 
   # Rule V3.4a: metal4 overlap of via3.
   logger.info('Executing rule V3.4a')
-  via3_4a_l1 = via3.enclosed(metal4, 0.01.um, euclidian).polygons(0.001)
+  via3_4a_l1 = via3.enclosed(metal4, 0.01.um, euclidian).polygons(0.001.um)
   via3_4a_l2 = via3.not(metal4)
   via3_4a_l = via3_4a_l1.or(via3_4a_l2)
   via3_4a_l.output('V3.4a', 'V3.4a : metal4 overlap of via3 >= 0.01 um')

--- a/klayout/drc/rule_decks/via4.drc
+++ b/klayout/drc/rule_decks/via4.drc
@@ -22,7 +22,7 @@ if BEOL && (METAL_LEVEL == '5LM' || METAL_LEVEL == '6LM')
 
   # Rule V4.1: Min/max Via1 size . is 0.26µm
   logger.info('Executing rule V4.1')
-  v41_l1 = via4.edges.without_length(0.26.um).extended(0, 0, 0.001, 0.001)
+  v41_l1 = via4.edges.without_length(0.26.um)
   v41_l1.output('V4.1', 'V4.1 : Min/max Via1 size . : 0.26µm')
   v41_l1.forget
 
@@ -56,7 +56,7 @@ if BEOL && (METAL_LEVEL == '5LM' || METAL_LEVEL == '6LM')
   # Rule V4.3b: metal4  overlap of via4.
   logger.info('Executing rule V4.3b')
   v43b_l1 = via4.not(metal4)
-  v43b_l2 = via4.enclosed(metal4, 0.01.um, euclidian).polygons(0.001)
+  v43b_l2 = via4.enclosed(metal4, 0.01.um, euclidian).polygons(0.001.um)
   v43b_l = v43b_l1.or(v43b_l2)
   v43b_l.output('V4.3b', 'V4.3b : metal4 overlap of via4 >= 0.01')
   v43b_l1.forget
@@ -106,7 +106,7 @@ if BEOL && (METAL_LEVEL == '5LM' || METAL_LEVEL == '6LM')
 
   # Rule V4.4a: metal5 overlap of via4.
   logger.info('Executing rule V4.4a')
-  via4_4a_l1 = via4.enclosed(metal5, 0.01.um, euclidian).polygons(0.001)
+  via4_4a_l1 = via4.enclosed(metal5, 0.01.um, euclidian).polygons(0.001.um)
   via4_4a_l2 = via4.not(metal5)
   via4_4a_l = via4_4a_l1.or(via4_4a_l2)
   via4_4a_l.output('V4.4a', 'V4.4a : metal5 overlap of via4 >= 0.01 um')

--- a/klayout/drc/rule_decks/via5.drc
+++ b/klayout/drc/rule_decks/via5.drc
@@ -22,7 +22,7 @@ if BEOL && (METAL_LEVEL == '6LM')
 
   # Rule V5.1: Min/max Via1 size . is 0.26µm
   logger.info('Executing rule V5.1')
-  v51_l1 = via5.edges.without_length(0.26.um).extended(0, 0, 0.001, 0.001)
+  v51_l1 = via5.edges.without_length(0.26.um)
   v51_l1.output('V5.1', 'V5.1 : Min/max Via1 size . : 0.26µm')
   v51_l1.forget
 
@@ -56,7 +56,7 @@ if BEOL && (METAL_LEVEL == '6LM')
   # Rule V5.3b: metal5  overlap of via5.
   logger.info('Executing rule V5.3b')
   v53b_l1 = via5.not(metal5)
-  v53b_l2 = via5.enclosed(metal5, 0.01.um, euclidian).polygons(0.001)
+  v53b_l2 = via5.enclosed(metal5, 0.01.um, euclidian).polygons(0.001.um)
   v53b_l = v53b_l1.or(v53b_l2)
   v53b_l.output('V5.3b', 'V5.3b : metal5 overlap of via5 >= 0.01')
   v53b_l1.forget
@@ -102,7 +102,7 @@ if BEOL && (METAL_LEVEL == '6LM')
 
   # Rule V5.4a: metaltop overlap of via5.
   logger.info('Executing rule V5.4a')
-  via5_4a_l1 = via5.enclosed(metaltop, 0.01.um, euclidian).polygons(0.001)
+  via5_4a_l1 = via5.enclosed(metaltop, 0.01.um, euclidian).polygons(0.001.um)
   via5_4a_l2 = via5.not(metaltop)
   via5_4a_l = via5_4a_l1.or(via5_4a_l2)
   via5_4a_l.output('V5.4a', 'V5.4a : metaltop overlap of via5 >= 0.01 um')


### PR DESCRIPTION
- Cleaning all DRC rules from unnecessary polygons and extended command
- Making sure all DRC values are in um

- Fixing #86 
- Fixing https://github.com/efabless/globalfoundries-pdk-libs-gf180mcu_fd_pr/issues/34